### PR TITLE
Add email for Chegg.com

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1435,7 +1435,8 @@
         "name": "Chegg",
         "url": "https://www.chegg.com/contactus",
         "difficulty": "hard",
-        "notes": "Call customer service or contact them via chat and ask them to delete your account, or request assistance via their Twitter account, <a href=\"https://twitter.com/chegghelp\">@CheggHelp</a>. There is also no option to delete your payment methods, you need to contact customer support as well.",
+        "notes": "Call customer service, email them with the email listed here, contact them via chat and ask them to delete your account, or request assistance via their Twitter account, <a href=\"https://twitter.com/chegghelp\">@CheggHelp</a>. There is also no option to delete your payment methods, you need to contact customer support as well.",
+        "email": "closemyaccount@chegg.com"
         "domains": [
             "chegg.com"
         ]


### PR DESCRIPTION
Added the email "closemyaccount@chegg.com" as a contact email for deleting your Chegg account.